### PR TITLE
feat(cognee-frontend): production container image for the cognee web UI

### DIFF
--- a/containers/cognee-frontend/Dockerfile
+++ b/containers/cognee-frontend/Dockerfile
@@ -1,0 +1,68 @@
+## cognee-frontend
+##
+## Upstream (topoteretes/cognee, cognee-frontend/) publishes no container image
+## and ships only a dev-mode Dockerfile (`npm run dev`). This builds a proper
+## production image: fetch the frontend source at the latest cognee release tag,
+## `next build`, and serve with `next start`.
+##
+## NEXT_PUBLIC_* vars are inlined into the browser bundle at BUILD time, so the
+## backend API URL must be baked here (not injected at runtime). Override the
+## default with `--build-arg NEXT_PUBLIC_BACKEND_API_URL=...` if needed.
+
+## Stage 1: fetch the frontend source at the latest stable cognee release tag
+FROM debian:stable-slim@sha256:ee12ffb55625b99d62837a72f037d9b2f18fd0c787a89c2b9a4f09666c48776c AS fetcher
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl jq ca-certificates
+
+RUN LATEST_TAG=$(curl -sX GET "https://api.github.com/repos/topoteretes/cognee/releases" \
+      | jq --raw-output '[.[] | select(.tag_name | test("^v?[0-9]+\\.[0-9]+\\.[0-9]+$"))][0].tag_name') \
+    && echo "TAG=${LATEST_TAG}" > /tmp/version_info \
+    && curl -fsSL "https://github.com/topoteretes/cognee/archive/refs/tags/${LATEST_TAG}.tar.gz" -o /tmp/cognee.tar.gz \
+    && mkdir -p /tmp/cognee-src \
+    && tar -xzf /tmp/cognee.tar.gz -C /tmp/cognee-src --strip-components=1 \
+    && test -d /tmp/cognee-src/cognee-frontend
+
+## Stage 2: install deps and build the Next.js app
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS builder
+
+WORKDIR /app
+
+COPY --from=fetcher /tmp/cognee-src/cognee-frontend/package.json /tmp/cognee-src/cognee-frontend/package-lock.json ./
+RUN npm ci && npm rebuild lightningcss
+
+COPY --from=fetcher /tmp/cognee-src/cognee-frontend/ ./
+# Upstream ships both next.config.mjs and next.config.ts; Next.js refuses to
+# start with two config files, so drop the empty .mjs and keep the .ts one.
+RUN rm -f next.config.mjs
+
+# NEXT_PUBLIC_* are inlined at build time. Point the browser at the public API.
+ARG NEXT_PUBLIC_BACKEND_API_URL=https://cognee.kien.cc/api
+ARG NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT=false
+ENV NEXT_PUBLIC_BACKEND_API_URL=${NEXT_PUBLIC_BACKEND_API_URL}
+ENV NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT=${NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT}
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN npm run build
+
+## Stage 3: runtime
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
+
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+
+# Non-root runtime user (matches the convention of other images in this repo).
+RUN addgroup -g 10001 cognee && adduser -D -u 10001 -G cognee cognee
+
+COPY --from=builder --chown=10001:10001 /app/package.json /app/package-lock.json ./
+COPY --from=builder --chown=10001:10001 /app/node_modules ./node_modules
+COPY --from=builder --chown=10001:10001 /app/.next ./.next
+COPY --from=builder --chown=10001:10001 /app/public ./public
+COPY --from=builder --chown=10001:10001 /app/next.config.ts ./
+
+USER cognee
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]

--- a/containers/cognee-frontend/PLATFORM
+++ b/containers/cognee-frontend/PLATFORM
@@ -1,0 +1,1 @@
+linux/amd64,linux/arm64

--- a/containers/cognee-frontend/README.md
+++ b/containers/cognee-frontend/README.md
@@ -1,0 +1,39 @@
+# cognee-frontend
+
+Production container image for the [cognee](https://github.com/topoteretes/cognee)
+web UI (`cognee-frontend/`, a Next.js app).
+
+## Why this exists
+
+Upstream publishes **no** container image for the frontend and ships only a
+dev-mode `Dockerfile` (`npm run dev`). This builds a proper production image:
+
+1. **fetcher** — resolves the latest stable `topoteretes/cognee` release tag,
+   downloads the source tarball and extracts `cognee-frontend/`.
+2. **builder** — `npm ci`, drops the conflicting `next.config.mjs` (upstream
+   ships both `.mjs` and `.ts`, and Next.js refuses to start with two configs),
+   then `next build`.
+3. **runtime** — serves with `next start` as a non-root user (uid/gid `10001`).
+
+## Build-time configuration
+
+`NEXT_PUBLIC_*` variables are inlined into the browser bundle at **build** time,
+so they cannot be injected at runtime. They are baked via build args:
+
+| Build arg | Default |
+| --- | --- |
+| `NEXT_PUBLIC_BACKEND_API_URL` | `https://cognee.kien.cc/api` |
+| `NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT` | `false` |
+
+The `dedsxc/labs` release workflow passes no build args, so the defaults above
+are what ship in the published image.
+
+## Runtime
+
+- Listens on port `3000` (`PORT=3000`).
+- `CMD ["npm", "run", "start"]` → `next start`.
+
+## Versioning
+
+`VERSION` resolves the latest stable `topoteretes/cognee` release tag (stripping
+the leading `v`), so the image version tracks upstream cognee releases.

--- a/containers/cognee-frontend/VERSION
+++ b/containers/cognee-frontend/VERSION
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+version=$(curl -sX GET "https://api.github.com/repos/topoteretes/cognee/releases" | jq --raw-output '[.[] | select(.tag_name | test("^v?[0-9]+\\.[0-9]+\\.[0-9]+$"))][0].tag_name' | sed 's/^v//')
+printf "%s" "${version}"


### PR DESCRIPTION
## What

Adds a `containers/cognee-frontend/` image. Upstream (`topoteretes/cognee`, `cognee-frontend/`) publishes **no** container image and ships only a dev-mode Dockerfile (`npm run dev`).

## How

Multi-stage build:
1. **fetcher** (debian-slim) — resolves the latest stable cognee release tag, downloads the source tarball and extracts `cognee-frontend/`.
2. **builder** (node:22-alpine) — `npm ci` + `npm rebuild lightningcss`, removes the conflicting `next.config.mjs` (upstream ships both `.mjs` and `.ts`; Next.js refuses two configs), then `next build`.
3. **runtime** (node:22-alpine) — `next start` as non-root user (uid/gid `10001`), port `3000`.

## Build-time config

`NEXT_PUBLIC_*` vars are inlined into the browser bundle at build time, so `NEXT_PUBLIC_BACKEND_API_URL` is baked (default `https://cognee.kien.cc/api`) and `NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT=false`. The release workflow passes no build args, so defaults ship.

## Versioning

`VERSION` tracks the latest stable `topoteretes/cognee` release tag (currently `1.3.0`).

Follow-up: add a `cognee-frontend` sub-chart in gitops-charts (host `cognee-ui.kien.cc`, port 3000, behind ip-allowlist).