### PR TITLE
feat(cognee-frontend): production container image for the Cognee web UI

### DIFF
--- a/containers/cognee-frontend/Dockerfile
+++ b/containers/cognee-frontend/Dockerfile
@@ -1,0 +1,90 @@
+## cognee-frontend
+##
+## Upstream (topoteretes/cognee, cognee-frontend/) ships the Next.js web UI for
+## Cognee but publishes no container image, and its own Dockerfile runs the app
+## in dev mode (`npm run dev`). This builds a proper production image: fetch the
+## frontend source at the latest stable cognee release tag, `next build` with
+## standalone output, and serve `server.js` as a non-root user.
+##
+## NEXT_PUBLIC_* vars are inlined into the browser bundle at BUILD time. We bake
+## literal placeholders (ENV NAME=NAME) and swap them for the container's real
+## env values at startup via entrypoint.sh, so the backend API URL and mode stay
+## configurable at RUNTIME.
+
+## Stage 1: fetch the frontend source at the latest stable cognee release tag
+FROM debian:stable-slim@sha256:328d16499860ae6cb9b345e2e4cebca08c2a36e4f7278482c7bd1f39d71e5bfd AS fetcher
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl jq ca-certificates
+
+# Only consider proper "vX.Y.Z" releases (skip prerelease .devN tags).
+RUN LATEST_TAG=$(curl -sX GET "https://api.github.com/repos/topoteretes/cognee/releases" \
+      | jq --raw-output '[.[] | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))][0].tag_name') \
+    && curl -fsSL "https://github.com/topoteretes/cognee/archive/refs/tags/${LATEST_TAG}.tar.gz" -o /tmp/cognee.tar.gz \
+    && mkdir -p /tmp/cognee-src \
+    && tar -xzf /tmp/cognee.tar.gz -C /tmp/cognee-src --strip-components=1 \
+    && test -d /tmp/cognee-src/cognee-frontend
+
+## Stage 2: install deps and build the Next.js app (npm, standalone output)
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS builder
+
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+COPY --from=fetcher /tmp/cognee-src/cognee-frontend/ ./
+RUN npm ci && npm rebuild lightningcss
+
+# Upstream's next.config.mjs does not enable standalone output (nor keep the
+# googleusercontent image host from next.config.ts). Override it so `next build`
+# emits a self-contained server.js bundle we can run without the full repo.
+RUN printf '%s\n' \
+      '/** @type {import("next").NextConfig} */' \
+      'const nextConfig = {' \
+      '  output: "standalone",' \
+      '  images: {' \
+      '    remotePatterns: [{ protocol: "https", hostname: "lh3.googleusercontent.com" }],' \
+      '  },' \
+      '};' \
+      'export default nextConfig;' \
+      > next.config.mjs \
+    && rm -f next.config.ts
+
+ENV NEXT_TELEMETRY_DISABLED=1
+# NEXT_PUBLIC_* are inlined at build time. Bake literal placeholders (name ==
+# value) so entrypoint.sh can swap them for real env values at runtime. Each
+# placeholder MUST be declared here for the substitution to work.
+ENV NEXT_PUBLIC_LOCAL_API_URL=NEXT_PUBLIC_LOCAL_API_URL
+ENV NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT=NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT
+ENV NEXT_PUBLIC_COGWIT_API_KEY=NEXT_PUBLIC_COGWIT_API_KEY
+
+RUN npm run build
+
+## Stage 3: runtime
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
+
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+# Default to OSS/local mode; the shared frontend defaults to cloud otherwise.
+ENV NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT=false
+ENV NEXT_PUBLIC_LOCAL_API_URL=http://localhost:8000
+
+# Non-root runtime user (matches the convention of other images in this repo).
+RUN addgroup -g 10001 cognee && adduser -D -u 10001 -G cognee cognee
+
+# Standalone output bundles a minimal server.js + only the needed node_modules.
+COPY --from=builder --chown=10001:10001 /app/public ./public
+COPY --from=builder --chown=10001:10001 /app/.next/standalone ./
+COPY --from=builder --chown=10001:10001 /app/.next/static ./.next/static
+COPY --chown=10001:10001 entrypoint.sh /home/cognee/entrypoint.sh
+RUN chmod +x /home/cognee/entrypoint.sh
+
+USER cognee
+
+EXPOSE 3000
+
+ENTRYPOINT ["/home/cognee/entrypoint.sh"]
+CMD ["node", "server.js"]

--- a/containers/cognee-frontend/Dockerfile
+++ b/containers/cognee-frontend/Dockerfile
@@ -56,6 +56,11 @@ ENV NEXT_PUBLIC_LOCAL_API_URL=NEXT_PUBLIC_LOCAL_API_URL
 ENV NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT=NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT
 ENV NEXT_PUBLIC_COGWIT_API_KEY=NEXT_PUBLIC_COGWIT_API_KEY
 
+# v1.4.0 carries a stale suppression above the d3-force-3d dynamic import.
+# The dependency now provides types, so TypeScript rejects the unused directive.
+RUN sed -i '/@ts-expect-error d3-force-3d has no types/d' \
+      'src/app/(graph)/GraphVisualization.tsx'
+
 RUN npm run build
 
 ## Stage 3: runtime

--- a/containers/cognee-frontend/PLATFORM
+++ b/containers/cognee-frontend/PLATFORM
@@ -1,0 +1,1 @@
+linux/amd64

--- a/containers/cognee-frontend/README.md
+++ b/containers/cognee-frontend/README.md
@@ -1,0 +1,57 @@
+# cognee-frontend
+
+Production container image for the [Cognee](https://github.com/topoteretes/cognee)
+web UI (`cognee-frontend/`, a Next.js app), the browser frontend that sits in
+front of the Cognee API.
+
+## Why this exists
+
+Upstream ships the frontend source but publishes **no** container image, and its
+own `Dockerfile` runs the app in development mode (`npm run dev`). This builds a
+proper production image:
+
+1. **fetcher** — resolves the latest stable `topoteretes/cognee` release tag
+   (proper `vX.Y.Z` only, skipping `.devN` prereleases), downloads the source
+   tarball and extracts `cognee-frontend/`.
+2. **builder** — `npm ci` + `npm rebuild lightningcss`, injects a
+   `next.config.mjs` that enables `output: "standalone"` (upstream sets neither
+   standalone output nor a single canonical config), then `next build`.
+3. **runtime** — serves the standalone `server.js` as a non-root user
+   (uid/gid `10001`) on port `3000`.
+
+## Runtime configuration
+
+`NEXT_PUBLIC_*` variables are inlined into the browser bundle at **build** time,
+so they cannot normally be injected at runtime. This image bakes literal
+placeholders (`ENV NAME=NAME`) at build time and swaps them for the container's
+real environment values at startup via `entrypoint.sh`.
+
+That keeps these configurable at **runtime**:
+
+| Env var | Purpose | Default |
+| --- | --- | --- |
+| `NEXT_PUBLIC_LOCAL_API_URL` | Base URL of the Cognee API the UI talks to (local/OSS mode) | `http://localhost:8000` |
+| `NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT` | `false` selects OSS/local mode; anything else is cloud mode | `false` |
+| `NEXT_PUBLIC_COGWIT_API_KEY` | Optional API key for authenticated requests | _(unset)_ |
+
+New `NEXT_PUBLIC_*` vars must be declared as `ENV NAME=NAME` in the Dockerfile
+**and** listed in `entrypoint.sh`, or the substitution won't happen.
+
+## Runtime
+
+- Listens on port `3000` (`PORT=3000`, `HOSTNAME=0.0.0.0`).
+- `ENTRYPOINT` runs `entrypoint.sh` (placeholder substitution) then
+  `CMD ["node", "server.js"]`.
+- Ships in OSS/local mode by default (`NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT=false`).
+
+## Platform
+
+Built for `linux/amd64` only, matching the other Next.js image in this repo
+(`mem0-dashboard`) whose `arm64` build fails under the CI's QEMU emulation. This
+is a web UI with no need to run on arm nodes; schedule the pod on an amd64 node
+(e.g. a `nodeSelector`).
+
+## Versioning
+
+`VERSION` resolves the latest stable `topoteretes/cognee` release tag (stripping
+the leading `v`), so the image version tracks upstream cognee releases.

--- a/containers/cognee-frontend/VERSION
+++ b/containers/cognee-frontend/VERSION
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+version=$(curl -sX GET "https://api.github.com/repos/topoteretes/cognee/releases" | jq --raw-output '[.[] | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))][0].tag_name' | sed 's/^v//')
+printf "%s" "${version}"

--- a/containers/cognee-frontend/entrypoint.sh
+++ b/containers/cognee-frontend/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+# NEXT_PUBLIC_* variables are inlined into the browser bundle at BUILD time.
+# The image is built with literal placeholders (ENV NAME=NAME) so they can be
+# swapped for the container's real environment values here, at startup. This
+# keeps the API URL and cloud/local mode configurable at RUNTIME.
+#
+# Each variable listed below MUST also be declared as `ENV NAME=NAME` in the
+# Dockerfile builder stage, otherwise there is no placeholder to substitute.
+PLACEHOLDERS="NEXT_PUBLIC_LOCAL_API_URL NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT NEXT_PUBLIC_COGWIT_API_KEY"
+
+for name in $PLACEHOLDERS; do
+  # Resolve the real runtime value; fall back to the placeholder itself so an
+  # unset variable is left untouched rather than blanked out.
+  value=$(printenv "$name" || true)
+  [ -z "$value" ] && value="$name"
+
+  # Rewrite every occurrence of the placeholder token in the built assets.
+  find /app/.next /app/public -type f 2>/dev/null \
+    | while IFS= read -r file; do
+        if grep -q "$name" "$file" 2>/dev/null; then
+          sed -i "s|$name|$value|g" "$file"
+        fi
+      done
+done
+
+exec "$@"


### PR DESCRIPTION
Upstream topoteretes/cognee ships the cognee-frontend/ Next.js source but publishes no image, and its own Dockerfile runs the app in dev mode. Add a multi-stage production image modeled on mem0-dashboard: fetch the source at the latest stable release tag, inject a next.config with standalone output, next build, and serve server.js as a non-root user on port 3000.

NEXT_PUBLIC_* vars are baked as placeholders and swapped at runtime via entrypoint.sh so the backend API URL and cloud/local mode stay configurable.