### PR TITLE
fix(cognee-frontend): avoid insecure dataset redirects

### DIFF
--- a/containers/cognee-frontend/Dockerfile
+++ b/containers/cognee-frontend/Dockerfile
@@ -58,8 +58,17 @@ ENV NEXT_PUBLIC_COGWIT_API_KEY=NEXT_PUBLIC_COGWIT_API_KEY
 
 # v1.4.0 carries a stale suppression above the d3-force-3d dynamic import.
 # The dependency now provides types, so TypeScript rejects the unused directive.
+# It also requests the datasets collection with a trailing slash while the API
+# declares the route without one. FastAPI redirects that request using the
+# internal HTTP scheme behind Traefik; browsers then block the HTTPS-to-HTTP
+# redirect. Use the canonical no-trailing-slash URL and avoid the redirect.
 RUN sed -i '/@ts-expect-error d3-force-3d has no types/d' \
-      'src/app/(graph)/GraphVisualization.tsx'
+      'src/app/(graph)/GraphVisualization.tsx' \
+    && sed -i \
+      -e 's|instance.fetch("/v1/datasets/",|instance.fetch("/v1/datasets",|' \
+      -e 's|instance.fetch(`/v1/datasets/`,|instance.fetch(`/v1/datasets`,|' \
+      'src/modules/datasets/getDatasets.ts' \
+      'src/modules/datasets/createDataset.ts'
 
 RUN npm run build
 


### PR DESCRIPTION
## Problem

The frontend requests `/v1/datasets/` with a trailing slash, while Cognee's FastAPI route is declared without one. FastAPI returns a `307` redirect. Behind Traefik, the generated location uses the internal scheme and loses the external `/backend` prefix:

```text
GET https://localhost/backend/api/v1/datasets/
307 Location: http://localhost/api/v1/datasets
```

Browsers block this HTTPS-to-HTTP redirect as mixed content and `fetch()` reports `TypeError: Failed to fetch`.

## Fix

Patch the upstream v1.4.0 frontend during image build to use the canonical no-trailing-slash collection URL for both dataset reads and creation:

```text
/v1/datasets/ → /v1/datasets
```

This avoids the redirect entirely while keeping the same-origin `/backend` routing.