### PR TITLE
fix(containers): link Garmin image to labs package

### DIFF
--- a/containers/garmin-mcp/Dockerfile
+++ b/containers/garmin-mcp/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.12.11-slim-bookworm
 
 ARG GARMIN_MCP_COMMIT=3610be6feed93088d85b0f35aba9d7d07c2505a7
 
+LABEL org.opencontainers.image.source="https://github.com/dedsxc/labs" \
+      org.opencontainers.image.description="Garmin Connect MCP server"
+
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \


### PR DESCRIPTION
Adds the OCI source label required by GHCR to associate the image package with `dedsxc/labs` and inherit repository Actions permissions. This fixes the cluster `403 Forbidden` image pull.