### PR TITLE
fix(opensre): build official 0.1.2026.8.27 release

### DIFF
--- a/containers/opensre/Dockerfile
+++ b/containers/opensre/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-ARG OPENSRE_COMMIT=7eef52a0304405b1a4174f322d286bcc4d805f5f
+ARG OPENSRE_VERSION=v0.1.2026.8.27
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -14,7 +14,7 @@ WORKDIR /app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential ca-certificates git \
     && git clone https://github.com/Tracer-Cloud/opensre.git /src/opensre \
-    && cd /src/opensre && git checkout --detach "${OPENSRE_COMMIT}" \
+    && cd /src/opensre && git checkout --detach "${OPENSRE_VERSION}" \
     && python -m pip install --upgrade pip \
     && python -m pip install "/src/opensre[postgresql]" \
     && rm -rf /src /root/.cache /var/lib/apt/lists/* \

--- a/containers/opensre/README.md
+++ b/containers/opensre/README.md
@@ -1,6 +1,6 @@
 # OpenSRE
 
-Reproducible build of [OpenSRE](https://github.com/Tracer-Cloud/opensre) pinned to an upstream commit.
+Reproducible build of [OpenSRE](https://github.com/Tracer-Cloud/opensre) pinned to an upstream release tag.
 
 The container runs the FastAPI web runtime on port `8000` as a non-root user. Update both `opensre/containers/opensre/Dockerfile` and `VERSION` when bumping upstream.
 

--- a/containers/opensre/VERSION
+++ b/containers/opensre/VERSION
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-printf '%s' '0.1.0-7eef52a7'
+printf '%s' '0.1.2026.8.27'


### PR DESCRIPTION
Use the latest official OpenSRE release `v0.1.2026.8.27` (`cb283516`) instead of an arbitrary main snapshot.

Validation: release/tag verified through the GitHub API; container build covered by CI.